### PR TITLE
chore: add tensile config for @fluentui/web-components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ rush.json
 
 # tsdoc
 tsdoc-metadata.json
+
+# benchmarking
+.tensile/

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -178,7 +178,7 @@
   "scripts": {
     "tsc": "tsc",
     "api-extractor": "api-extractor",
-    "benchmark": "tsc -p ./tsconfig.bench.json && npx tensile --file ./dist/esm/button/button.bench.js",
+    "benchmark": "tsc -p ./tsconfig.bench.json && tensile --file ./dist/esm/button/button.bench.js --config ./tensile.config.js",
     "compile": "node ./scripts/compile",
     "clean": "node ./scripts/clean dist",
     "generate-api": "api-extractor run --local",

--- a/packages/web-components/tensile.config.js
+++ b/packages/web-components/tensile.config.js
@@ -1,0 +1,13 @@
+const config = {
+  // Browsers to test against
+  browsers: ['chrome'],
+
+  // Importmaps for your test.
+  // See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap
+  imports: {
+    '@tensile-perf/web-components': '/node_modules/@tensile-perf/web-components/dist/index.js',
+    '@microsoft/fast-element': '/node_modules/@microsoft/fast-element/dist/fast-element.min.js',
+  },
+};
+
+export default config;


### PR DESCRIPTION
- Adds a `tensile` config.
- Adds a "tensile" entry to .gitignore
- Updates the command to execute `tensile`

NOTE: the test still doesn't run because `button.bench.ts` is not being built. Additionally the file path is relative to the generated `.tensile` folder so it should be updated to `../dist...` or the generated `.bench.js` file should be written to the `.tensile` folder. Up to you how you want to handle it.