### PR TITLE
add a temporary fix for non-ESM benchmark dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,7 @@ tsdoc-metadata.json
 
 # benchmarking
 .tensile/
+
+# tools cache
+.swc
+.nx/cache

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -178,8 +178,9 @@
   "scripts": {
     "tsc": "tsc",
     "api-extractor": "api-extractor",
-    "benchmark": "yarn clean && yarn compile && tensile --file ./dist/esm/button/button.bench.js --config ./tensile.config.js",
+    "benchmark": "yarn clean && yarn compile:benchmark && yarn compile && tensile --file ./dist/esm/button/button.bench.js --config ./tensile.config.js",
     "compile": "node ./scripts/compile",
+    "compile:benchmark": "rollup -c rollup.bench.js",
     "clean": "node ./scripts/clean dist",
     "generate-api": "api-extractor run --local",
     "build": "yarn compile && rollup -c && yarn generate-api",
@@ -206,7 +207,7 @@
     "@microsoft/fast-element": "2.0.0-beta.26",
     "@microsoft/fast-foundation": "3.0.0-alpha.31",
     "@microsoft/fast-web-utilities": "^6.0.0",
-    "@fluentui/tokens": "1.0.0-alpha.15",
+    "@fluentui/tokens": "1.0.0-alpha.16",
     "tslib": "^2.1.0"
   },
   "beachball": {

--- a/packages/web-components/rollup.bench.js
+++ b/packages/web-components/rollup.bench.js
@@ -1,0 +1,21 @@
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import esbuild from 'rollup-plugin-esbuild';
+import commonJS from 'rollup-plugin-commonjs';
+
+const plugins = [nodeResolve({ browser: true }), commonJS(), esbuild({ tsconfig: './tsconfig.json' })];
+
+export default [
+  {
+    input: {
+      tokens: './src/utils/benchmark-dependencies/tokens.ts',
+    },
+    output: [
+      {
+        dir: './.tensile/benchmark-dependencies',
+        format: 'esm',
+        sourcemap: true,
+      },
+    ],
+    plugins,
+  },
+];

--- a/packages/web-components/src/utils/benchmark-dependencies/README.md
+++ b/packages/web-components/src/utils/benchmark-dependencies/README.md
@@ -1,0 +1,7 @@
+# Benchamrk Depedencies
+
+This is a list of dependencis used in benchmarking that lack native ESM artifacts. Over time this
+list should go away entirely but, for now, this allows us to output ESM versions of dependencies
+with Rollup.
+
+Built with `rollup.bench.js` in the package root.

--- a/packages/web-components/src/utils/benchmark-dependencies/README.md
+++ b/packages/web-components/src/utils/benchmark-dependencies/README.md
@@ -1,6 +1,6 @@
 # Benchamrk Depedencies
 
-This is a list of dependencis used in benchmarking that lack native ESM artifacts. Over time this
+This is a list of dependencies used in benchmarking that lack native ESM artifacts. Over time this
 list should go away entirely but, for now, this allows us to output ESM versions of dependencies
 with Rollup.
 

--- a/packages/web-components/src/utils/benchmark-dependencies/tokens.ts
+++ b/packages/web-components/src/utils/benchmark-dependencies/tokens.ts
@@ -1,0 +1,1 @@
+export * from '@fluentui/tokens';

--- a/packages/web-components/tensile.config.js
+++ b/packages/web-components/tensile.config.js
@@ -11,7 +11,7 @@ const config = {
     '@microsoft/fast-foundation': '/node_modules/@microsoft/fast-foundation/dist/esm/index.js',
     '@microsoft/fast-foundation/utilities.js': '/node_modules/@microsoft/fast-foundation/dist/esm/utilities/index.js',
     '@microsoft/fast-web-utilities': '/node_modules/@microsoft/fast-web-utilities/dist/index.js',
-    '@fluentui/tokens': '/node_modules/@fluentui/tokens/lib/index.js',
+    '@fluentui/tokens': '/tensile-assets/benchmark-dependencies/tokens.js',
     '@fluentui/web-components': '/node_modules/@fluentui/web-components/dist/esm/index.js',
     '@floating-ui/dom': '/node_modules/@floating-ui/dom/dist/floating-ui.dom.esm.js',
     '@floating-ui/core': '/node_modules/@floating-ui/core/dist/floating-ui.core.esm.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1673,6 +1673,13 @@
     "@griffel/react" "^1.0.0"
     tslib "^2.1.0"
 
+"@fluentui/tokens@1.0.0-alpha.16":
+  version "1.0.0-alpha.16"
+  resolved "https://registry.yarnpkg.com/@fluentui/tokens/-/tokens-1.0.0-alpha.16.tgz#57adedcb926e7649c46e77e079f0b92cbb43bb54"
+  integrity sha512-Gr9G8LIlUhZYX5j6CfDQrofQqsWAz/q54KabWn1tWV/1083WwyoTZXiG1k6b37NnK7Feye7D7Nz+4MNqoKpXGw==
+  dependencies:
+    "@swc/helpers" "^0.5.1"
+
 "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -4964,6 +4971,13 @@
   version "0.4.14"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.14.tgz#1352ac6d95e3617ccb7c1498ff019654f1e12a74"
   integrity sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==
+  dependencies:
+    tslib "^2.4.0"
+
+"@swc/helpers@^0.5.1":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.8.tgz#65d56b1961487fd99795ffd8c68edb7a591571fb"
+  integrity sha512-lruDGw3pnfM3wmZHeW7JuhkGQaJjPyiKjxeGhdmfoOT53Ic9qb5JLDNaK2HUdl1zLDeX28H221UvKjfdvSLVMg==
   dependencies:
     tslib "^2.4.0"
 


### PR DESCRIPTION
## Previous Behavior

Tokens did not have a browser-compatible ESM build.

## New Behavior

We use Rollup to generate a browser-compatible ESM build for tokens.
