### PR TITLE
update progress bar for element internals

### DIFF
--- a/packages/web-components/src/progress-bar/progress-bar.spec.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.spec.ts
@@ -1,78 +1,70 @@
 import { expect, test } from '@playwright/test';
-import type { Locator, Page } from '@playwright/test';
 import { fixtureURL } from '../helpers.tests.js';
 import type { ProgressBar } from './progress-bar.js';
 
 test.describe('Progress Bar', () => {
-  let page: Page;
-  let element: Locator;
-  let root: Locator;
-
-  test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage();
-
-    element = page.locator('fluent-progress-bar');
-
-    root = page.locator('#root');
-
+  test.beforeEach(async ({ page }) => {
     await page.goto(fixtureURL('components-progressbar--progress'));
+
+    await page.waitForFunction(() => customElements.whenDefined('fluent-progress-bar'));
   });
 
-  test.afterAll(async () => {
-    await page.close();
-  });
+  test('should include a role of progressbar', async ({ page }) => {
+    const element = page.locator('fluent-progress-bar');
 
-  // Foundation tests
-  test('should include a role of progressbar', async () => {
     await expect(element).toHaveJSProperty('elementInternals.role', 'progressbar');
   });
 
-  test('should set the `aria-valuenow` attribute with the `value` property when provided', async () => {
-    await root.evaluate(node => {
-      node.innerHTML = /* html */ `
-            <fluent-progress-bar value="50"></fluent-progress-bar>
-        `;
-    });
+  test('should set the `aria-valuenow` attribute with the `value` property when provided', async ({ page }) => {
+    const element = page.locator('fluent-progress-bar');
+
+    await page.setContent(/* html */ `
+        <fluent-progress-bar value="50"></fluent-progress-bar>
+    `);
 
     await expect(element).toHaveJSProperty('elementInternals.ariaValueNow', '50');
   });
 
-  test('should set the `aria-valuemin` attribute with the `min` property when provided', async () => {
-    await root.evaluate(node => {
-      node.innerHTML = /* html */ `
-            <fluent-progress-bar min="50"></fluent-progress-bar>
-        `;
-    });
+  test('should set the `aria-valuemin` attribute with the `min` property when provided', async ({ page }) => {
+    const element = page.locator('fluent-progress-bar');
+
+    await page.setContent(/* html */ `
+      <fluent-progress-bar min="50"></fluent-progress-bar>
+    `);
 
     await expect(element).toHaveJSProperty('elementInternals.ariaValueMin', '50');
   });
 
-  test('should set the `aria-valuemax` attribute with the `max` property when provided', async () => {
-    await root.evaluate(node => {
-      node.innerHTML = /* html */ `
-            <fluent-progress-bar max="50"></fluent-progress-bar>
-        `;
-    });
+  test('should set the `aria-valuemax` attribute with the `max` property when provided', async ({ page }) => {
+    const element = page.locator('fluent-progress-bar');
+
+    await page.setContent(/* html */ `
+        <fluent-progress-bar max="50"></fluent-progress-bar>
+    `);
 
     await expect(element).toHaveJSProperty('elementInternals.ariaValueMax', '50');
   });
 
-  test('should return the `percentComplete` property as a value between 0 and 100 when `min` and `max` are unset', async () => {
-    await root.evaluate(node => {
-      node.innerHTML = /* html */ `
-            <fluent-progress-bar value="50"></fluent-progress-bar>
-        `;
-    });
+  test('should return the `percentComplete` property as a value between 0 and 100 when `min` and `max` are unset', async ({
+    page,
+  }) => {
+    const element = page.locator('fluent-progress-bar');
+
+    await page.setContent(/* html */ `
+        <fluent-progress-bar value="50"></fluent-progress-bar>
+    `);
 
     await expect(element).toHaveJSProperty('percentComplete', 50);
   });
 
-  test('should set the `percentComplete` property to match the current `value` in the range of `min` and `max`', async () => {
-    await root.evaluate(node => {
-      node.innerHTML = /* html */ `
-            <fluent-progress-bar value="0"></fluent-progress-bar>
-        `;
-    });
+  test('should set the `percentComplete` property to match the current `value` in the range of `min` and `max`', async ({
+    page,
+  }) => {
+    const element = page.locator('fluent-progress-bar');
+
+    await page.setContent(/* html */ `
+        <fluent-progress-bar value="0"></fluent-progress-bar>
+    `);
 
     await expect(element).toHaveJSProperty('percentComplete', 0);
 
@@ -101,8 +93,9 @@ test.describe('Progress Bar', () => {
     await expect(element).toHaveJSProperty('percentComplete', 0);
   });
 
-  // Fluent Specific propertiy tests
-  test('should set and retrieve the `thickness` property correctly', async () => {
+  test('should set and retrieve the `thickness` property correctly', async ({ page }) => {
+    const element = page.locator('fluent-progress-bar');
+
     await element.evaluate((node: ProgressBar) => {
       node.thickness = 'medium';
     });
@@ -116,7 +109,9 @@ test.describe('Progress Bar', () => {
     await expect(element).toHaveJSProperty('thickness', 'large');
   });
 
-  test('should set and retrieve the `shape` property correctly', async () => {
+  test('should set and retrieve the `shape` property correctly', async ({ page }) => {
+    const element = page.locator('fluent-progress-bar');
+
     await element.evaluate((node: ProgressBar) => {
       node.shape = 'square';
     });
@@ -130,7 +125,9 @@ test.describe('Progress Bar', () => {
     await expect(element).toHaveJSProperty('shape', 'rounded');
   });
 
-  test('should set and retrieve the `validationState` property correctly', async () => {
+  test('should set and retrieve the `validationState` property correctly', async ({ page }) => {
+    const element = page.locator('fluent-progress-bar');
+
     await element.evaluate((node: ProgressBar) => {
       node.validationState = 'success';
     });

--- a/packages/web-components/src/progress-bar/progress-bar.stories.ts
+++ b/packages/web-components/src/progress-bar/progress-bar.stories.ts
@@ -74,7 +74,7 @@ export const Max = renderComponent(html<ProgressStoryArgs>`
       <fluent-progress-bar value="3" max="10"></fluent-progress-bar>
     </p>
     <p>
-      <code>3 o 5</code>
+      <code>3 of 5</code>
       <fluent-progress-bar value="3" max="5"></fluent-progress-bar>
     </p>
   </div>


### PR DESCRIPTION
## Previous Behavior

- Tests were synchronous
- Explicit calls were needed to update the `percentComplete`
- ARIA properties were being set in multiple places

## New Behavior

- Tests are async
- `percentComplete` is now marked with `@volatile`, so any changes to properties used by it get set when those properties change
- ARIA properties are automatically set when attributes change, and only when necessary
